### PR TITLE
Added a line to the Vim section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ cmake-build-debug/
 
 #vim
 *.swp
+*.swo
 
 build/*
 !build/.keep


### PR DESCRIPTION
.swo is sometimes used if .swp exists. There may be like .swr and
beyind, but I've never run into it.