### PR TITLE
Changed the way .vimrc is sourced.

### DIFF
--- a/.src
+++ b/.src
@@ -1,2 +1,2 @@
-alias vim='vim -S `git rev-parse --show-toplevel`/.vimrc'
+alias vim='vim -u `git rev-parse --show-toplevel`/.vimrc'
 alias cmake='cd `git rev-parse --show-toplevel`/build && cmake ..'


### PR DESCRIPTION
With the original option of -S, stuff was not working right. This way
everyone's vim will be working the exact same. Continuity!!